### PR TITLE
fix staging env domain, add make targets start and clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,20 @@
+start:
+	## run as: make start db=<hostname_of_postgres_server>
+	psql -d learntogether -h "$(db)" -f scripts/createTables.sql
+	npm install
+	bower install --allow-root
+	nodemon server/server
+
 test:
 	@NODE_ENV=test ./node_modules/.bin/mocha --reporter xunit "test/server/**/*.js" | grep "<" > report.xml
 
 test-local:
 	@./node_modules/.bin/mocha --reporter spec "test/server/**/*.js"
 
-.PHONY: test test-local
+cleanup:
+	@rm -r node_modules client/public/vendor
+	@node cache clear
+	@bower cache clean
+
+
+.PHONY: start test test-local cleanup

--- a/server/config/env/staging.js
+++ b/server/config/env/staging.js
@@ -3,7 +3,7 @@
 var fs = require('fs');
 
 module.exports = {
-	domain: "localhost",
+	domain: "learntogether.io",
 	http_port: process.env.HTTP_PORT || 80,
 	https_port: process.env.HTTPS_PORT || 443,
 	private_key: fs.readFileSync(__dirname + '/ssl/local-key.pem', 'utf-8'),


### PR DESCRIPTION
hitting learntogether.io:80 would redirect to localhost:443, fixed this in staging.js environment
added Makefile targets: 
"start":  run db config script, install dependencies, start application
"cleanup": delete dependencies, clear package management cache

@fmnguyen, update database cleanup script (just the tables, leave database/users intact) for use in Makefile cleanup